### PR TITLE
support XML tagName selectors

### DIFF
--- a/rule.coffee
+++ b/rule.coffee
@@ -254,7 +254,7 @@ class Rule
         elementArray = hash[elementKey] ? hash[elementKey] = []
         elementArray.push(child)
       # Index tag names
-      elementKey = child.tagName
+      elementKey = child.tagName.toUpperCase()
       elementArray = hash[elementKey] ? hash[elementKey] = []
       elementArray.push(child)
       # Recurse


### PR DESCRIPTION
This PR converts all `tagName` in the lookup table to uppercase to support XML element selectors such as `svg` and `use`.

https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName#Value